### PR TITLE
Change the type of azs and instance_type to String

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,12 +25,12 @@ variable "private_subnet_name" {}
 variable Main_Routing_Table {}
 variable "azs" {
   description = "Run the EC2 Instances in these Availability Zones"
-  type = "list"
+  type = list(string)
   default = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 variable "environment" { default = "dev" }
 variable "instance_type" {
-  type = "map"
+  type = map(string)
   default = {
     dev = "t2.nano"
     test = "t2.micro"


### PR DESCRIPTION
Hello Sai,

The following error occured while executing terraform init command and I correct it as per the commands shown in your video.

Errorr Message:
=============

"Error: Invalid quoted type constraints
on variables.tf line 31, in variable "instance_type":
31:   type = "map"
Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "map" and write map(string) instead to explicitly indicate that the map elements are strings."